### PR TITLE
Use rosflight_msg for GPS on EKF

### DIFF
--- a/include/ekf/ekf.h
+++ b/include/ekf/ekf.h
@@ -13,7 +13,7 @@
 #include <deque>
 #include <lib/eigen.h>
 #include <eigen_conversions/eigen_msg.h>
-#include <fcu_common/GPS.h>
+#include <rosflight_msgs/GPS.h>
 
 // state numbers
 #define PN 0
@@ -93,12 +93,12 @@ private:
   // Functions
   void mocapCallback(const geometry_msgs::TransformStamped msg);
   void imuCallback(const sensor_msgs::Imu msg);
-  void gpsCallback(const fcu_common::GPS msg);
+  void gpsCallback(const rosflight_msgs::GPS msg);
   void predictStep();
   void updateStep();
   void updateIMU(sensor_msgs::Imu msg);
   void updateMocap(geometry_msgs::TransformStamped msg);
-  void updateGPS(fcu_common::GPS msg);
+  void updateGPS(rosflight_msgs::GPS msg);
   void initializeX(geometry_msgs::TransformStamped msg);
   void predictTimerCallback(const ros::TimerEvent& event);
   void publishTimerCallback(const ros::TimerEvent& event);

--- a/src/ekf/ekf.cpp
+++ b/src/ekf/ekf.cpp
@@ -87,7 +87,7 @@ void mocapFilter::mocapCallback(const geometry_msgs::TransformStamped msg)
   return;
 }
 
-void mocapFilter::gpsCallback(const fcu_common::GPS msg)
+void mocapFilter::gpsCallback(const rosflight_msgs::GPS msg)
 {
   if(!flying_){
     ROS_INFO_THROTTLE(1,"Not flying, but GPS signal received");
@@ -195,7 +195,7 @@ void mocapFilter::updateMocap(geometry_msgs::TransformStamped msg)
   x_hat_ = x_hat_ + L*(y - C*x_hat_);
 }
 
-void mocapFilter::updateGPS(fcu_common::GPS msg)
+void mocapFilter::updateGPS(rosflight_msgs::GPS msg)
 {
   ROS_INFO_STREAM("Update GPS");
 


### PR DESCRIPTION
Changed the includes/objects in EKF for GPS from fcu_common to rosflight_msgs. 

@superjax Not sure if this is correct, but catkin was failing to build until I made this change.