### PR TITLE
heading wraps to avoid discontinuity when flying with changing headings

### DIFF
--- a/roscopter/src/mekf/mekf.cpp
+++ b/roscopter/src/mekf/mekf.cpp
@@ -364,6 +364,12 @@ void kalmanFilter::magCallback(const sensor_msgs::MagneticField msg)
     // compute measurement error
     double r = y_mag - h_mag;
 
+    // wrap heading measurement
+    while (r > PI)
+      r = r - 2 * PI;
+    while (r < -PI)
+      r = r + 2 * PI;
+
     // compute delta_x
     Eigen::Matrix<double, NUM_ERROR_STATES, 1> delta_x = K * r;
 


### PR DESCRIPTION
I added wrapping to the heading measurement just like we do in the UAV book and ROSPlane.  Without this change, the estimator will fail when you try to fly the copter around in a circle (heading changing as you go) because of the discontinuity when suddenly going from PI to -PI.
![wrap_heading](https://user-images.githubusercontent.com/21351818/30496503-ce0fe246-9a0c-11e7-8a77-46e79014601c.png)
