### PR TITLE
fixed roscopter_sim launch file and added back roscopter_sim params file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This is intended to eventually be a fully-featured multirotor autopilot for ROS.  It will be built according to the method published in [Quadrotor Dynamics and Control](http://scholarsarchive.byu.edu/cgi/viewcontent.cgi?article=2324&context=facpub), so as to allow anyone to easily understand, modify and use the code.  The framework developed in the afore mentioned reference closely resembles the fixed wing framework developed in Small Unmanned Aircraft by Beard and McLain.  This framework is inherently modular and extensively documented so as to aid the user in understanding and extending for personal use.
 
-The package is intended to be used with fcu\_io or fcu\_sim, for hardware with a naze32 or spracingf3 (or derivatives) or simulation, respectively.
+The package is intended to be used with rosflight\_io or roscopter\_sim, for hardware with a naze32 or spracingf3 (or derivatives) or simulation, respectively.
 
 It is a single ROS package, with several nodes.
 
-# - EKF 
+# - EKF
 
 The ekf package contains a standard mekf, as defined mostly in the way in the reference above.  We are probably going to release a new version of the Quadrotor Dynamics and Control to resemble more closely the modeling in this node.  We are estimating position, velocity, and attitude as well as accelerometer biases, velocities are body fixed, and the accelerometer biases allow for better estimation and control long term.   The model and jacobians are defined explicitly in the doc/ekf_jacobians.pdf document
 

--- a/roscopter_sim/launch/multirotor.launch
+++ b/roscopter_sim/launch/multirotor.launch
@@ -1,6 +1,7 @@
 <!-- multirotor.launch - Author: James Jackson - BYU - 2016 -->
 <!-- This is a launch file that runs the bare minimum requirements to get -->
-<!-- gazebo running with a multirotor -->
+<!-- gazebo running with a multirotor. This launch file is meant for when -->
+<!-- rosflight_sil is not active -->
 
 <launch>
   <arg name="mav_name"            default="multirotor"/>
@@ -39,25 +40,33 @@
     <!-- Is Flying Publisher -->
     <node pkg="rostopic" type="rostopic" name="is_flying_pub" args="pub is_flying std_msgs/Bool true"/>
 
+    <!-- Status Publisher -->
+    <node pkg="rostopic" type="rostopic" name="status_pub" args="pub -r 1 status rosflight_msgs/Status '{armed: true, failsafe: false, rc_override: false, offboard: true, error_code: 0, num_errors: 0, loop_time_us: 1}'"/>
+
     <!-- State Estimator -->
-    <node pkg="roscopter" type="mekf" name="mekf" output="screen"/>
+    <node pkg="roscopter" type="mekf" name="mekf" output="screen">
+      <remap from="baro" to="baro/data"/>
+      <remap from="sonar" to="sonar/data"/>
+      <remap from="magnetometer" to="mag/data"/>
+    </node>
 
     <!-- PID Position Controller -->
     <node name="controller" pkg="roscopter" type="controller">
       <!-- <remap from="estimate" to="ground_truth/odometry/NED"/> -->
-      <!-- <remap from="estimate" to="estimate"/> -->
+      <remap from="estimate" to="estimate"/>
     </node>
 
     <!-- Waypoint Manager -->
     <node name="waypoint_manager" pkg="roscopter" type="waypoint_manager.py" output="screen">
       <remap from="waypoint" to="high_level_command"/>
+      <!-- <remap from="state" to="ground_truth/odometry/NED"/> -->
       <remap from="state" to="estimate"/>
     </node>
 
     <!-- plot states -->
-    <!-- <node pkg="roscopter" type="states_plotter.py" name="states_plotter" output="screen">
+    <node pkg="roscopter" type="states_plotter.py" name="states_plotter" output="screen">
       <param name="time_window" value="10.0"/>
-    </node> -->
+    </node>
 
   </group>
 

--- a/roscopter_sim/params/multirotor.yaml
+++ b/roscopter_sim/params/multirotor.yaml
@@ -1,13 +1,49 @@
+### Simplified Dynamics ###
+
+dynamics: {
+
+mass: 2.856,
+linear_mu: 0.2,
+angular_mu: 0.3,
+ground_effect: [-55.3516, 181.8265, -203.9874, 85.3735, -7.6619],
+
+max_l: 6.5080,
+max_m: 5.087,
+max_n: 0.25,
+max_F: 59.844,
+tau_up_l: 0.1904,
+tau_up_m: 0.1904,
+tau_up_n: 0.1644,
+tau_up_F: 0.1644,
+tau_down_l: 0.1904,
+tau_down_m: 0.1904,
+tau_down_n: 0.2164,
+tau_down_F: 0.2164,
+roll_P: 25.0,
+roll_I: 0.0,
+roll_D: 8.0,
+pitch_P: 25.0,
+pitch_I: 0.0,
+pitch_D: 8.0,
+yaw_P: 25.0,
+yaw_I: 0.0,
+yaw_D: 0.0,
+alt_P: 16.0,
+alt_I: 5.0,
+alt_D: 32.0
+
+}
+
 ### Waypoints ###
 
 waypoint_manager: {
 
 waypoints:
  [[0, 0, -2, 0],
- [5, 5, -2, 0],
- [-1.4, 2.7, -2, 0],
- [-2.6, -4.3, -2, 0],
- [2.7, -2.7, -2, 0]],
+ [5, 5, -2, 2.3],
+ [-1.4, 2.7, -2, 3.9],
+ [-2.6, -4.3, -2, 5.5],
+ [2.7, -2.7, -2, 0.78]],
 
 threshold: 1,
 cyle: True
@@ -20,27 +56,27 @@ controller: {
 
 u_P: 0.3,
 u_I: 0.0,
-u_D: 0.1,
+u_D: 0.01,
 
 v_P: 0.3,
 v_I: 0.0,
-v_D: 0.1,
+v_D: 0.0,
 
 w_P: 0.3,
-w_I: 0.0,
-w_D: 0.0,
+w_I: 0.1,
+w_D: 0.45,
 
-x_P: 0.45,
+x_P: 0.4,
 x_I: 0.0,
-x_D: 0.1,
+x_D: 0.2,
 
-y_P: 0.45,
+y_P: 0.4,
 y_I: 0.0,
-y_D: 0.1,
+y_D: 0.2,
 
-z_P: 0.75,
+z_P: 0.9,
 z_I: 0.2,
-z_D: 0.1,
+z_D: 0.35,
 
 psi_P: 1.0,
 psi_I: 0.0,


### PR DESCRIPTION
These changes fix up the repo so that `roslaunch roscopter_sim multirotor.launch` works again.  Some changes had been made in the estimator (for integration with ROSflight) which broke some things when rosflight_sil / rosflight_io wasn't active.  To address this I added a rosflight/Status message publisher and some mekf topic re-mappings inside of multirotor.launch.