### PR TITLE
Added missing return statements

### DIFF
--- a/roscopter/src/ekf/meas.cpp
+++ b/roscopter/src/ekf/meas.cpp
@@ -34,6 +34,8 @@ std::string Base::Type() const
     case ZERO_VEL:
         return "ZeroVel";
         break;
+    default:
+        return "unknown";
     }
 }
 

--- a/roscopter/src/ekf/state.cpp
+++ b/roscopter/src/ekf/state.cpp
@@ -172,7 +172,7 @@ State& State::operator+=(const VectorXd& dx)
     bb += dx(ErrorState::DBB);
     ref += dx(ErrorState::DREF);
 
-    *this;
+    return *this;
 }
 
 State& State::operator+=(const ErrorState& dx)


### PR DESCRIPTION
The compiler was complaining about these. Also, one of the += overloads `State& State::operator+=(const VectorXd& dx)` was not returning the instance, which might have caused problems for any code that uses that operator (if there is any code out there using it).